### PR TITLE
Fix error on unknown node

### DIFF
--- a/actions/pathfinder.lua
+++ b/actions/pathfinder.lua
@@ -103,7 +103,7 @@ local function is_good_node(node, exceptions)
       break
     end
   end
-  if not minetest.registered_nodes[node.name].walkable then
+  if node.name ~= nil and not minetest.registered_nodes[node.name].walkable then
     return pathfinder.node_types.walkable
   elseif is_openable then
     return pathfinder.node_types.openable

--- a/actions/pathfinder.lua
+++ b/actions/pathfinder.lua
@@ -103,7 +103,7 @@ local function is_good_node(node, exceptions)
       break
     end
   end
-  if node.name ~= nil and not minetest.registered_nodes[node.name].walkable then
+  if node ~= nil and node.name ~= nil and not minetest.registered_nodes[node.name].walkable then
     return pathfinder.node_types.walkable
   elseif is_openable then
     return pathfinder.node_types.openable


### PR DESCRIPTION
I encounter, on my server, some random error on advanced_npc function about "can not index nil value". The server crash and we must restart it.

The problems comes because we have deactivated some mod that have already created some nodes in our world. In this case, the function is_good_node try to handle the missing node and gets mads.

Here is the fix I've done on our world to avoid the crash. I'm considering those node as non walkable to avoid any interraction with them and avoid subsequent errors.

I'd like to thank you for your mod :-)
